### PR TITLE
feat: rule updates for no-extra-parens and rest-spread-spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,7 +107,7 @@ module.exports = {
         "no-eval": "error",
         "no-extra-parens": [
             "error",
-            "all",
+            "functions",
         ],
         "no-extra-semi": "error",
         "no-floating-decimal": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -177,10 +177,7 @@ module.exports = {
             "consistent-as-needed",
         ],
         "quotes": "error",
-        "rest-spread-spacing": [
-            "error",
-            "always",
-        ],
+        "rest-spread-spacing": "error",
         "semi": "error",
         "semi-spacing": "error",
         "semi-style": "error",


### PR DESCRIPTION
The `no-extra-parens` rule was configured in such a way that it conflicted with the `no-mixed-operators` rule, which asks that you use extra parens to clarify the intended order of operations.  This rule has been updated to only apply to function expressions.

The `rest-spread-spacing` rule was configured incorrectly to require a space between the rest/spread operator and its expression, which I didn't intend to do originally.  This has also been fixed.