### PR TITLE
feat: disable unicorn/prevent-abbreviations rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -199,5 +199,6 @@ module.exports = {
         "unicorn/no-useless-undefined": "off",
         "unicorn/prefer-object-from-entries": "off",
         "unicorn/prefer-ternary": "off",
+        "unicorn/prevent-abbreviations": "off",
     },
 };


### PR DESCRIPTION
this rule is more trouble than it's worth, as it prevents the usage of variables like `i` to be used within loops